### PR TITLE
Support for piecewise split of Job result

### DIFF
--- a/Src/Client.ts
+++ b/Src/Client.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { v4 as uuidv4 } from 'uuid';
 import * as Share from './Share';
+import { makePieceStr } from './Utils/ParseCsv';
 import { validateDataId, validateJobUuid } from './Utils/ValidataUuid';
 import { SendSharesRequest, DeleteSharesRequest, GetSchemaRequest, ExecuteComputationRequest, GetComputationResultRequest, JoinOrder, Input, SendModelParamRequest, PredictRequest } from "./Proto/libc_to_manage_pb";
 import { LibcToManageClient } from './Proto/Libc_to_manageServiceClientPb';
@@ -295,25 +296,23 @@ export class Client {
         if(params.length != this.endpoints.length) {
             throw new Error("パラメータのシェアの形式がパーティ数に対応していません.");
         }
-
         const modelParamJobUuid: string = uuidv4();
-        let reqs: SendModelParamRequest[] = [];
-        for(const param of params) {
-            const req = new SendModelParamRequest();
-            req.setJobUuid(modelParamJobUuid);
-            req.setParams(JSON.stringify(param));
-            req.setToken(this.token);
-            reqs.push(req);
+
+        const promises = [];
+        for(let i = 0; i < this.clients.length; ++i) {
+            const pieceStr = makePieceStr(JSON.stringify(params[i]), 5);
+            for(let pieceId: number = 0; pieceId < pieceStr.length; ++pieceId) {
+                const req = new SendModelParamRequest();
+                req.setJobUuid(modelParamJobUuid);
+                req.setParams(pieceStr[pieceId]);
+                req.setPieceId(pieceId+1);
+                req.setToken(this.token);
+                promises.push(this.clients[i].sendModelParam(req, {}))
+            }
         }
 
         let isOk: boolean = true;
         let message: string = "ok";
-
-        const promises = [];
-        for(let i = 0; i < this.clients.length; i++) {
-            promises.push(this.clients[i].sendModelParam(reqs[i], {}))
-        }
-
         await Promise.all(promises)
         .then((res) => {
             for(let i = 0; i < res.length; i++) {

--- a/Src/Client.ts
+++ b/Src/Client.ts
@@ -229,13 +229,13 @@ export class Client {
             const call = client.getComputationResult(req, {});
 
             // Receive data via stream
-            const resList: object[] = [];
+            const resList: {isOk: boolean, pieceId: number, result: string, status: JobStatus}[] = [];
             call.on('data', function(response: any) {
                 resList.push({
-                  "isOk": response.getIsOk(),
-                  "pieceId": response.getPieceId(),
-                  "result": response.getResult(),
-                  "status": response.getStatus()
+                  isOk: response.getIsOk(),
+                  pieceId: response.getPieceId(),
+                  result: response.getResult(),
+                  status: response.getStatus()
                 });
             });
 
@@ -247,7 +247,7 @@ export class Client {
                     let isOk = true;
                     for (const res of resList) {
                         result += JSON.parse(res.result);
-                        isOk &= res.isOk;
+                        isOk &&= res.isOk;
                     }
                     const status = resList[0].status;
                     resolve({"isOk": isOk, "status": status, "result": result});
@@ -258,13 +258,13 @@ export class Client {
             }))
         }
 
-        let results: string[][] | string[][][] | object = [];
+        let results: string[][] | string[][][] | any = [];
         const statuses: JobStatus[] = [];
         let isOk = true
         await Promise.all(promises)
-        .then((responses) => {
+        .then((responses: any) => {
             for (const res of responses) {
-                isOk &= res.isOk;
+                isOk &&= res.isOk;
                 statuses.push(res.status)
                 results.push(JSON.parse(res.result))
             }

--- a/Src/Client.ts
+++ b/Src/Client.ts
@@ -246,7 +246,7 @@ export class Client {
                     let result = "";
                     let isOk = true;
                     for (const res of resList) {
-                        result += res.result;
+                        result += JSON.parse(res.result);
                         isOk &= res.isOk;
                     }
                     const status = resList[0].status;

--- a/Src/Proto/Libc_to_manageServiceClientPb.ts
+++ b/Src/Proto/Libc_to_manageServiceClientPb.ts
@@ -35,7 +35,7 @@ export class LibcToManageClient {
     this.options_ = options;
   }
 
-  methodDescriptorSendShares = new grpcWeb.MethodDescriptor(
+  methodInfoSendShares = new grpcWeb.MethodDescriptor(
     '/libctomanage.LibcToManage/SendShares',
     grpcWeb.MethodType.UNARY,
     libc_to_manage_pb.SendSharesRequest,
@@ -67,7 +67,7 @@ export class LibcToManageClient {
           '/libctomanage.LibcToManage/SendShares',
         request,
         metadata || {},
-        this.methodDescriptorSendShares,
+        this.methodInfoSendShares,
         callback);
     }
     return this.client_.unaryCall(
@@ -75,10 +75,10 @@ export class LibcToManageClient {
       '/libctomanage.LibcToManage/SendShares',
     request,
     metadata || {},
-    this.methodDescriptorSendShares);
+    this.methodInfoSendShares);
   }
 
-  methodDescriptorDeleteShares = new grpcWeb.MethodDescriptor(
+  methodInfoDeleteShares = new grpcWeb.MethodDescriptor(
     '/libctomanage.LibcToManage/DeleteShares',
     grpcWeb.MethodType.UNARY,
     libc_to_manage_pb.DeleteSharesRequest,
@@ -110,7 +110,7 @@ export class LibcToManageClient {
           '/libctomanage.LibcToManage/DeleteShares',
         request,
         metadata || {},
-        this.methodDescriptorDeleteShares,
+        this.methodInfoDeleteShares,
         callback);
     }
     return this.client_.unaryCall(
@@ -118,10 +118,10 @@ export class LibcToManageClient {
       '/libctomanage.LibcToManage/DeleteShares',
     request,
     metadata || {},
-    this.methodDescriptorDeleteShares);
+    this.methodInfoDeleteShares);
   }
 
-  methodDescriptorGetSchema = new grpcWeb.MethodDescriptor(
+  methodInfoGetSchema = new grpcWeb.MethodDescriptor(
     '/libctomanage.LibcToManage/GetSchema',
     grpcWeb.MethodType.UNARY,
     libc_to_manage_pb.GetSchemaRequest,
@@ -153,7 +153,7 @@ export class LibcToManageClient {
           '/libctomanage.LibcToManage/GetSchema',
         request,
         metadata || {},
-        this.methodDescriptorGetSchema,
+        this.methodInfoGetSchema,
         callback);
     }
     return this.client_.unaryCall(
@@ -161,10 +161,10 @@ export class LibcToManageClient {
       '/libctomanage.LibcToManage/GetSchema',
     request,
     metadata || {},
-    this.methodDescriptorGetSchema);
+    this.methodInfoGetSchema);
   }
 
-  methodDescriptorExecuteComputation = new grpcWeb.MethodDescriptor(
+  methodInfoExecuteComputation = new grpcWeb.MethodDescriptor(
     '/libctomanage.LibcToManage/ExecuteComputation',
     grpcWeb.MethodType.UNARY,
     libc_to_manage_pb.ExecuteComputationRequest,
@@ -196,7 +196,7 @@ export class LibcToManageClient {
           '/libctomanage.LibcToManage/ExecuteComputation',
         request,
         metadata || {},
-        this.methodDescriptorExecuteComputation,
+        this.methodInfoExecuteComputation,
         callback);
     }
     return this.client_.unaryCall(
@@ -204,12 +204,12 @@ export class LibcToManageClient {
       '/libctomanage.LibcToManage/ExecuteComputation',
     request,
     metadata || {},
-    this.methodDescriptorExecuteComputation);
+    this.methodInfoExecuteComputation);
   }
 
-  methodDescriptorGetComputationResult = new grpcWeb.MethodDescriptor(
+  methodInfoGetComputationResult = new grpcWeb.MethodDescriptor(
     '/libctomanage.LibcToManage/GetComputationResult',
-    grpcWeb.MethodType.UNARY,
+    grpcWeb.MethodType.SERVER_STREAMING,
     libc_to_manage_pb.GetComputationResultRequest,
     libc_to_manage_pb.GetComputationResultResponse,
     (request: libc_to_manage_pb.GetComputationResultRequest) => {
@@ -220,37 +220,16 @@ export class LibcToManageClient {
 
   getComputationResult(
     request: libc_to_manage_pb.GetComputationResultRequest,
-    metadata: grpcWeb.Metadata | null): Promise<libc_to_manage_pb.GetComputationResultResponse>;
-
-  getComputationResult(
-    request: libc_to_manage_pb.GetComputationResultRequest,
-    metadata: grpcWeb.Metadata | null,
-    callback: (err: grpcWeb.RpcError,
-               response: libc_to_manage_pb.GetComputationResultResponse) => void): grpcWeb.ClientReadableStream<libc_to_manage_pb.GetComputationResultResponse>;
-
-  getComputationResult(
-    request: libc_to_manage_pb.GetComputationResultRequest,
-    metadata: grpcWeb.Metadata | null,
-    callback?: (err: grpcWeb.RpcError,
-               response: libc_to_manage_pb.GetComputationResultResponse) => void) {
-    if (callback !== undefined) {
-      return this.client_.rpcCall(
-        this.hostname_ +
-          '/libctomanage.LibcToManage/GetComputationResult',
-        request,
-        metadata || {},
-        this.methodDescriptorGetComputationResult,
-        callback);
-    }
-    return this.client_.unaryCall(
-    this.hostname_ +
-      '/libctomanage.LibcToManage/GetComputationResult',
-    request,
-    metadata || {},
-    this.methodDescriptorGetComputationResult);
+    metadata?: grpcWeb.Metadata) {
+    return this.client_.serverStreaming(
+      this.hostname_ +
+        '/libctomanage.LibcToManage/GetComputationResult',
+      request,
+      metadata || {},
+      this.methodInfoGetComputationResult);
   }
 
-  methodDescriptorSendModelParam = new grpcWeb.MethodDescriptor(
+  methodInfoSendModelParam = new grpcWeb.MethodDescriptor(
     '/libctomanage.LibcToManage/SendModelParam',
     grpcWeb.MethodType.UNARY,
     libc_to_manage_pb.SendModelParamRequest,
@@ -282,7 +261,7 @@ export class LibcToManageClient {
           '/libctomanage.LibcToManage/SendModelParam',
         request,
         metadata || {},
-        this.methodDescriptorSendModelParam,
+        this.methodInfoSendModelParam,
         callback);
     }
     return this.client_.unaryCall(
@@ -290,10 +269,10 @@ export class LibcToManageClient {
       '/libctomanage.LibcToManage/SendModelParam',
     request,
     metadata || {},
-    this.methodDescriptorSendModelParam);
+    this.methodInfoSendModelParam);
   }
 
-  methodDescriptorPredict = new grpcWeb.MethodDescriptor(
+  methodInfoPredict = new grpcWeb.MethodDescriptor(
     '/libctomanage.LibcToManage/Predict',
     grpcWeb.MethodType.UNARY,
     libc_to_manage_pb.PredictRequest,
@@ -325,7 +304,7 @@ export class LibcToManageClient {
           '/libctomanage.LibcToManage/Predict',
         request,
         metadata || {},
-        this.methodDescriptorPredict,
+        this.methodInfoPredict,
         callback);
     }
     return this.client_.unaryCall(
@@ -333,10 +312,10 @@ export class LibcToManageClient {
       '/libctomanage.LibcToManage/Predict',
     request,
     metadata || {},
-    this.methodDescriptorPredict);
+    this.methodInfoPredict);
   }
 
-  methodDescriptorGetDataList = new grpcWeb.MethodDescriptor(
+  methodInfoGetDataList = new grpcWeb.MethodDescriptor(
     '/libctomanage.LibcToManage/GetDataList',
     grpcWeb.MethodType.UNARY,
     libc_to_manage_pb.GetDataListRequest,
@@ -368,7 +347,7 @@ export class LibcToManageClient {
           '/libctomanage.LibcToManage/GetDataList',
         request,
         metadata || {},
-        this.methodDescriptorGetDataList,
+        this.methodInfoGetDataList,
         callback);
     }
     return this.client_.unaryCall(
@@ -376,7 +355,7 @@ export class LibcToManageClient {
       '/libctomanage.LibcToManage/GetDataList',
     request,
     metadata || {},
-    this.methodDescriptorGetDataList);
+    this.methodInfoGetDataList);
   }
 
 }

--- a/Src/Proto/libc_to_manage.proto
+++ b/Src/Proto/libc_to_manage.proto
@@ -14,7 +14,7 @@ service LibcToManage {
     rpc DeleteShares(DeleteSharesRequest) returns (DeleteSharesResponse) {}                          // シェアの削除リクエスト
     rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {}                                   // スキーマ取得リクエスト
     rpc ExecuteComputation(ExecuteComputationRequest) returns (ExecuteComputationResponse) {}        // 計算リクエスト
-    rpc GetComputationResult(GetComputationResultRequest) returns (GetComputationResultResponse) {}  // 計算結果取得リクエスト
+    rpc GetComputationResult(GetComputationResultRequest) returns (stream GetComputationResultResponse) {}  // 計算結果取得リクエスト
     rpc SendModelParam(SendModelParamRequest) returns (SendModelParamResponse) {}                    // モデルパラメータ送信リクエスト
     rpc Predict(PredictRequest) returns (PredictResponse) {}                                         // モデル値予測リクエスト
     rpc GetDataList(GetDataListRequest) returns (GetDataListResponse) {}                             // data一覧取得リクエスト
@@ -117,6 +117,7 @@ message GetComputationResultResponse {
     bool is_ok = 2;
     string result = 3;
     pb_common_types.JobStatus status = 4;
+    int32 piece_id = 5;
 }
 
 /**
@@ -125,7 +126,8 @@ message GetComputationResultResponse {
 message SendModelParamRequest {
     string job_uuid = 1;
     string params = 2;
-    string token = 3;
+    int32 piece_id = 3;
+    string token = 4;
 }
 
 /**

--- a/Src/Proto/libc_to_manage_grpc_pb.d.ts
+++ b/Src/Proto/libc_to_manage_grpc_pb.d.ts
@@ -58,7 +58,7 @@ interface ILibcToManageService_IExecuteComputation extends grpc.MethodDefinition
 interface ILibcToManageService_IGetComputationResult extends grpc.MethodDefinition<libc_to_manage_pb.GetComputationResultRequest, libc_to_manage_pb.GetComputationResultResponse> {
     path: "/libctomanage.LibcToManage/GetComputationResult";
     requestStream: false;
-    responseStream: false;
+    responseStream: true;
     requestSerialize: grpc.serialize<libc_to_manage_pb.GetComputationResultRequest>;
     requestDeserialize: grpc.deserialize<libc_to_manage_pb.GetComputationResultRequest>;
     responseSerialize: grpc.serialize<libc_to_manage_pb.GetComputationResultResponse>;
@@ -99,7 +99,7 @@ export interface ILibcToManageServer extends grpc.UntypedServiceImplementation {
     deleteShares: grpc.handleUnaryCall<libc_to_manage_pb.DeleteSharesRequest, libc_to_manage_pb.DeleteSharesResponse>;
     getSchema: grpc.handleUnaryCall<libc_to_manage_pb.GetSchemaRequest, libc_to_manage_pb.GetSchemaResponse>;
     executeComputation: grpc.handleUnaryCall<libc_to_manage_pb.ExecuteComputationRequest, libc_to_manage_pb.ExecuteComputationResponse>;
-    getComputationResult: grpc.handleUnaryCall<libc_to_manage_pb.GetComputationResultRequest, libc_to_manage_pb.GetComputationResultResponse>;
+    getComputationResult: grpc.handleServerStreamingCall<libc_to_manage_pb.GetComputationResultRequest, libc_to_manage_pb.GetComputationResultResponse>;
     sendModelParam: grpc.handleUnaryCall<libc_to_manage_pb.SendModelParamRequest, libc_to_manage_pb.SendModelParamResponse>;
     predict: grpc.handleUnaryCall<libc_to_manage_pb.PredictRequest, libc_to_manage_pb.PredictResponse>;
     getDataList: grpc.handleUnaryCall<libc_to_manage_pb.GetDataListRequest, libc_to_manage_pb.GetDataListResponse>;
@@ -118,9 +118,8 @@ export interface ILibcToManageClient {
     executeComputation(request: libc_to_manage_pb.ExecuteComputationRequest, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.ExecuteComputationResponse) => void): grpc.ClientUnaryCall;
     executeComputation(request: libc_to_manage_pb.ExecuteComputationRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.ExecuteComputationResponse) => void): grpc.ClientUnaryCall;
     executeComputation(request: libc_to_manage_pb.ExecuteComputationRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.ExecuteComputationResponse) => void): grpc.ClientUnaryCall;
-    getComputationResult(request: libc_to_manage_pb.GetComputationResultRequest, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.GetComputationResultResponse) => void): grpc.ClientUnaryCall;
-    getComputationResult(request: libc_to_manage_pb.GetComputationResultRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.GetComputationResultResponse) => void): grpc.ClientUnaryCall;
-    getComputationResult(request: libc_to_manage_pb.GetComputationResultRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.GetComputationResultResponse) => void): grpc.ClientUnaryCall;
+    getComputationResult(request: libc_to_manage_pb.GetComputationResultRequest, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<libc_to_manage_pb.GetComputationResultResponse>;
+    getComputationResult(request: libc_to_manage_pb.GetComputationResultRequest, metadata?: grpc.Metadata, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<libc_to_manage_pb.GetComputationResultResponse>;
     sendModelParam(request: libc_to_manage_pb.SendModelParamRequest, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.SendModelParamResponse) => void): grpc.ClientUnaryCall;
     sendModelParam(request: libc_to_manage_pb.SendModelParamRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.SendModelParamResponse) => void): grpc.ClientUnaryCall;
     sendModelParam(request: libc_to_manage_pb.SendModelParamRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.SendModelParamResponse) => void): grpc.ClientUnaryCall;
@@ -146,9 +145,8 @@ export class LibcToManageClient extends grpc.Client implements ILibcToManageClie
     public executeComputation(request: libc_to_manage_pb.ExecuteComputationRequest, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.ExecuteComputationResponse) => void): grpc.ClientUnaryCall;
     public executeComputation(request: libc_to_manage_pb.ExecuteComputationRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.ExecuteComputationResponse) => void): grpc.ClientUnaryCall;
     public executeComputation(request: libc_to_manage_pb.ExecuteComputationRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.ExecuteComputationResponse) => void): grpc.ClientUnaryCall;
-    public getComputationResult(request: libc_to_manage_pb.GetComputationResultRequest, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.GetComputationResultResponse) => void): grpc.ClientUnaryCall;
-    public getComputationResult(request: libc_to_manage_pb.GetComputationResultRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.GetComputationResultResponse) => void): grpc.ClientUnaryCall;
-    public getComputationResult(request: libc_to_manage_pb.GetComputationResultRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.GetComputationResultResponse) => void): grpc.ClientUnaryCall;
+    public getComputationResult(request: libc_to_manage_pb.GetComputationResultRequest, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<libc_to_manage_pb.GetComputationResultResponse>;
+    public getComputationResult(request: libc_to_manage_pb.GetComputationResultRequest, metadata?: grpc.Metadata, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<libc_to_manage_pb.GetComputationResultResponse>;
     public sendModelParam(request: libc_to_manage_pb.SendModelParamRequest, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.SendModelParamResponse) => void): grpc.ClientUnaryCall;
     public sendModelParam(request: libc_to_manage_pb.SendModelParamRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.SendModelParamResponse) => void): grpc.ClientUnaryCall;
     public sendModelParam(request: libc_to_manage_pb.SendModelParamRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: libc_to_manage_pb.SendModelParamResponse) => void): grpc.ClientUnaryCall;

--- a/Src/Proto/libc_to_manage_grpc_pb.js
+++ b/Src/Proto/libc_to_manage_grpc_pb.js
@@ -232,7 +232,7 @@ var LibcToManageService = exports.LibcToManageService = {
   getComputationResult: {
     path: '/libctomanage.LibcToManage/GetComputationResult',
     requestStream: false,
-    responseStream: false,
+    responseStream: true,
     requestType: libc_to_manage_pb.GetComputationResultRequest,
     responseType: libc_to_manage_pb.GetComputationResultResponse,
     requestSerialize: serialize_libctomanage_GetComputationResultRequest,

--- a/Src/Proto/libc_to_manage_pb.d.ts
+++ b/Src/Proto/libc_to_manage_pb.d.ts
@@ -314,6 +314,9 @@ export class GetComputationResultResponse extends jspb.Message {
   getStatus(): common_types_common_types_pb.JobStatus;
   setStatus(value: common_types_common_types_pb.JobStatus): GetComputationResultResponse;
 
+  getPieceId(): number;
+  setPieceId(value: number): GetComputationResultResponse;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): GetComputationResultResponse.AsObject;
   static toObject(includeInstance: boolean, msg: GetComputationResultResponse): GetComputationResultResponse.AsObject;
@@ -328,6 +331,7 @@ export namespace GetComputationResultResponse {
     isOk: boolean,
     result: string,
     status: common_types_common_types_pb.JobStatus,
+    pieceId: number,
   }
 }
 
@@ -337,6 +341,9 @@ export class SendModelParamRequest extends jspb.Message {
 
   getParams(): string;
   setParams(value: string): SendModelParamRequest;
+
+  getPieceId(): number;
+  setPieceId(value: number): SendModelParamRequest;
 
   getToken(): string;
   setToken(value: string): SendModelParamRequest;
@@ -353,6 +360,7 @@ export namespace SendModelParamRequest {
   export type AsObject = {
     jobUuid: string,
     params: string,
+    pieceId: number,
     token: string,
   }
 }

--- a/Src/Proto/libc_to_manage_pb.js
+++ b/Src/Proto/libc_to_manage_pb.js
@@ -2715,7 +2715,8 @@ proto.libctomanage.GetComputationResultResponse.toObject = function(includeInsta
     message: jspb.Message.getFieldWithDefault(msg, 1, ""),
     isOk: jspb.Message.getBooleanFieldWithDefault(msg, 2, false),
     result: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    status: jspb.Message.getFieldWithDefault(msg, 4, 0)
+    status: jspb.Message.getFieldWithDefault(msg, 4, 0),
+    pieceId: jspb.Message.getFieldWithDefault(msg, 5, 0)
   };
 
   if (includeInstance) {
@@ -2767,6 +2768,10 @@ proto.libctomanage.GetComputationResultResponse.deserializeBinaryFromReader = fu
     case 4:
       var value = /** @type {!proto.pb_common_types.JobStatus} */ (reader.readEnum());
       msg.setStatus(value);
+      break;
+    case 5:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setPieceId(value);
       break;
     default:
       reader.skipField();
@@ -2822,6 +2827,13 @@ proto.libctomanage.GetComputationResultResponse.serializeBinaryToWriter = functi
   if (f !== 0.0) {
     writer.writeEnum(
       4,
+      f
+    );
+  }
+  f = message.getPieceId();
+  if (f !== 0) {
+    writer.writeInt32(
+      5,
       f
     );
   }
@@ -2900,6 +2912,24 @@ proto.libctomanage.GetComputationResultResponse.prototype.setStatus = function(v
 };
 
 
+/**
+ * optional int32 piece_id = 5;
+ * @return {number}
+ */
+proto.libctomanage.GetComputationResultResponse.prototype.getPieceId = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 5, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.libctomanage.GetComputationResultResponse} returns this
+ */
+proto.libctomanage.GetComputationResultResponse.prototype.setPieceId = function(value) {
+  return jspb.Message.setProto3IntField(this, 5, value);
+};
+
+
 
 
 
@@ -2934,7 +2964,8 @@ proto.libctomanage.SendModelParamRequest.toObject = function(includeInstance, ms
   var f, obj = {
     jobUuid: jspb.Message.getFieldWithDefault(msg, 1, ""),
     params: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    token: jspb.Message.getFieldWithDefault(msg, 3, "")
+    pieceId: jspb.Message.getFieldWithDefault(msg, 3, 0),
+    token: jspb.Message.getFieldWithDefault(msg, 4, "")
   };
 
   if (includeInstance) {
@@ -2980,6 +3011,10 @@ proto.libctomanage.SendModelParamRequest.deserializeBinaryFromReader = function(
       msg.setParams(value);
       break;
     case 3:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setPieceId(value);
+      break;
+    case 4:
       var value = /** @type {string} */ (reader.readString());
       msg.setToken(value);
       break;
@@ -3026,10 +3061,17 @@ proto.libctomanage.SendModelParamRequest.serializeBinaryToWriter = function(mess
       f
     );
   }
+  f = message.getPieceId();
+  if (f !== 0) {
+    writer.writeInt32(
+      3,
+      f
+    );
+  }
   f = message.getToken();
   if (f.length > 0) {
     writer.writeString(
-      3,
+      4,
       f
     );
   }
@@ -3073,11 +3115,29 @@ proto.libctomanage.SendModelParamRequest.prototype.setParams = function(value) {
 
 
 /**
- * optional string token = 3;
+ * optional int32 piece_id = 3;
+ * @return {number}
+ */
+proto.libctomanage.SendModelParamRequest.prototype.getPieceId = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.libctomanage.SendModelParamRequest} returns this
+ */
+proto.libctomanage.SendModelParamRequest.prototype.setPieceId = function(value) {
+  return jspb.Message.setProto3IntField(this, 3, value);
+};
+
+
+/**
+ * optional string token = 4;
  * @return {string}
  */
 proto.libctomanage.SendModelParamRequest.prototype.getToken = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
 };
 
 
@@ -3086,7 +3146,7 @@ proto.libctomanage.SendModelParamRequest.prototype.getToken = function() {
  * @return {!proto.libctomanage.SendModelParamRequest} returns this
  */
 proto.libctomanage.SendModelParamRequest.prototype.setToken = function(value) {
-  return jspb.Message.setProto3StringField(this, 3, value);
+  return jspb.Message.setProto3StringField(this, 4, value);
 };
 
 

--- a/Src/Utils/ParseCsv.ts
+++ b/Src/Utils/ParseCsv.ts
@@ -32,8 +32,26 @@ export function parseCsv(data: string): [string[], number[][]]{
     return [schema, secrets];
 }
 
+function checkPieceSize(pieceSize: number) {
+    const lowerLimitSize: number = 1
+    const upperLimitSize: number = 1_000_000
+    if (pieceSize < lowerLimitSize) {
+        throw new Error(
+          "piece size " + pieceSize.toString() + " is over " +
+          "specified limit size " + lowerLimitSize.toString()
+        );
+    }
+    if (pieceSize > upperLimitSize) {
+        throw new Error(
+          "piece size " + pieceSize.toString() + " is under " +
+          "specified limit size " + upperLimitSize.toString()
+        );
+    }
+}
+
 // couchbaseに1回で保存できる上限が1MBなので、デフォルトでは1MBで分割する
 export function makePiece(secrets: number[][], pieceSize: number = 1000000): number[][][]{
+    checkPieceSize(pieceSize);
     let bytes: number = 0;
     let secretsPiece: number[][][] = [];
     secretsPiece.push([]);
@@ -47,6 +65,26 @@ export function makePiece(secrets: number[][], pieceSize: number = 1000000): num
     }
     return secretsPiece;
 }
+
+export function makePieceStr(str: string, pieceSize: number = 1000000): string[]{
+    checkPieceSize(pieceSize);
+
+    const strPiece: string[] = [];
+    let current: string = ""
+    for (const ch of str) {
+        current += ch;
+        if (current.length == pieceSize) {
+            strPiece.push(current);
+            current = "";
+        }
+    }
+    if (current.length > 0) {
+        strPiece.push(current);
+    }
+    return strPiece;
+}
+
+
 
 export function parseCsvVector(data: string): number[] {
     const array: string[] = sanitize(data).split(/\r\n|\n|\r/).filter((el)=>el.match(/[^,\s]/)); // サニタイズ処理とcsvの空白分の削除処理

--- a/Src/Utils/ParseCsv.ts
+++ b/Src/Utils/ParseCsv.ts
@@ -37,13 +37,13 @@ function checkPieceSize(pieceSize: number) {
     const upperLimitSize: number = 1_000_000
     if (pieceSize < lowerLimitSize) {
         throw new Error(
-          "piece size " + pieceSize.toString() + " is over " +
+          "piece size " + pieceSize.toString() + " is under " +
           "specified limit size " + lowerLimitSize.toString()
         );
     }
     if (pieceSize > upperLimitSize) {
         throw new Error(
-          "piece size " + pieceSize.toString() + " is under " +
+          "piece size " + pieceSize.toString() + " is over " +
           "specified limit size " + upperLimitSize.toString()
         );
     }

--- a/Tests/IntegrationTests/ClientTest/grpcServer.ts
+++ b/Tests/IntegrationTests/ClientTest/grpcServer.ts
@@ -33,13 +33,13 @@ function getComputationResult(call: any) {
     res1.setIsOk(true);
     res1.setStatus(JobStatus.COMPLETED);
     res1.setPieceId(1);
-    res1.setResult("[[\"1\"],[\"");
+    res1.setResult("\"[[\\\"1\\\"],[\\\"\"");
     call.write(res1);
     const res2 = new GetComputationResultResponse();
     res2.setMessage("ok");
     res2.setIsOk(true);
     res2.setPieceId(2);
-    res2.setResult("2\"],[\"3\"]]");
+    res2.setResult("\"2\\\"],[\\\"3\\\"]]\"");
     call.write(res2);
     call.end();
 }

--- a/Tests/IntegrationTests/ClientTest/grpcServer.ts
+++ b/Tests/IntegrationTests/ClientTest/grpcServer.ts
@@ -27,13 +27,21 @@ function executeComputation(call: any, callback: any) {
     callback(null, res);
 }
 
-function getComputationResult(call: any, callback: any) {
-    const res = new GetComputationResultResponse();
-    res.setMessage("ok");
-    res.setIsOk(true);
-    res.setStatus(JobStatus.COMPLETED);
-    res.setResult("[[\"1\"],[\"2\"],[\"3\"]]");
-    callback(null, res);
+function getComputationResult(call: any) {
+    const res1 = new GetComputationResultResponse();
+    res1.setMessage("ok");
+    res1.setIsOk(true);
+    res1.setStatus(JobStatus.COMPLETED);
+    res1.setPieceId(1);
+    res1.setResult("[[\"1\"],[\"");
+    call.write(res1);
+    const res2 = new GetComputationResultResponse();
+    res2.setMessage("ok");
+    res2.setIsOk(true);
+    res2.setPieceId(2);
+    res2.setResult("2\"],[\"3\"]]");
+    call.write(res2);
+    call.end();
 }
 
 function sendModelParam(call: any, callback: any) {

--- a/Tests/UnitTests/ParseCsv.test.ts
+++ b/Tests/UnitTests/ParseCsv.test.ts
@@ -1,4 +1,4 @@
-import { makePiece, parseCsv, parseCsvVector, parseJsonVector } from "../../Src/Utils/ParseCsv";
+import { makePiece, makePieceStr, parseCsv, parseCsvVector, parseJsonVector } from "../../Src/Utils/ParseCsv";
 
 const data: string = `id,attr1,attr2,attr3,attr4,attr5,attr6
 hoge,0,0.77,0.63,0.35,0.39,0.35
@@ -72,6 +72,35 @@ test('makePiece must make table pieces', () => {
     expect(JSON.stringify(pieces2) == JSON.stringify(piece_100)).toBe(true);
 })
 
+test('makePieceStr must make table pieces', () => {
+    const paramTuple: [number, string, string[]][] = [
+        // empty string
+        [1, "", []],
+        [3, "", []],
+        // normal piece
+        [6, "aaabbbcccddd", ["aaabbb", "cccddd"]],
+        [9, "aaabbbcccddd", ["aaabbbccc", "ddd"]],
+        [12, "aaabbbcccddd", ["aaabbbcccddd"]],
+        [15, "aaabbbcccddd", ["aaabbbcccddd"]],
+        // special character
+        [5, "!\"#$%&'()=~|-^@`[]{};+:*,<.>/?",
+          ["!\"#$%", "&'()=", "~|-^@", "`[]{}", ";+:*,", "<.>/?"]],
+    ];
+    for (const [pieceSize, str, expectedPiece] of paramTuple) {
+        const piece = makePieceStr(str, pieceSize);
+        expect(piece).toEqual(expectedPiece);
+    }
+})
+
+test('makePieceStr must throw when Beyond Constraints', () => {
+    const paramTuple: [number, string][] = [
+        [0, "string"],
+        [1_000_001, "string"],
+    ];
+    for (const [pieceSize, str] of paramTuple) {
+        expect(() => makePieceStr(str, pieceSize)).toThrow();
+    }
+})
 
 const model_data: string = `0,0.67,0.41,0.25,0.49,0.25`;
 const model_vector = [0, 0.67, 0.41, 0.25, 0.49,0.25];


### PR DESCRIPTION
depens on https://github.com/acompany-develop/QuickMPC/pull/4

# Summary
split job result

# Purpose
Successfully save to DB and return to Client when job result is huge.

# Contents
- Change return of lib to MC get_computation_result to stream
- Add ability to combine results in piece order when executing get_computation_result
- Change send_model_param to send split into pieces

# Testing Methods Performed
- pytest
- Send a request to get a join table job with larger data